### PR TITLE
改变主题色计时会出现跳动

### DIFF
--- a/mine_sweeping/lib/mine_sweeping_main.dart
+++ b/mine_sweeping/lib/mine_sweeping_main.dart
@@ -308,6 +308,8 @@ class _MineSweepingState extends State<MineSweeping> {
 
   ///游戏计时器
   void startTimer() {
+    //避免切换主题色导致计时跳动
+     _timer?.cancel();
     const duration = Duration(seconds: 1);
     _playTime = 0;
     _timer = Timer.periodic(duration, (timer) {


### PR DESCRIPTION
增加 _timer?.cancel();取消代码，或者使用Ticker来代替Timer计时。